### PR TITLE
Expand liability fields

### DIFF
--- a/finance_project/finance/migrations/0003_expand_liability.py
+++ b/finance_project/finance/migrations/0003_expand_liability.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('finance', '0002_bankaccount_stock'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='liability',
+            name='payment_amount',
+            field=models.DecimalField(blank=True, decimal_places=2, help_text='Regular payment amount', max_digits=10, null=True),
+        ),
+        migrations.AddField(
+            model_name='liability',
+            name='payment_frequency',
+            field=models.CharField(choices=[('week', 'Weekly'), ('month', 'Monthly'), ('year', 'Yearly')], default='month', max_length=10),
+        ),
+        migrations.AddField(
+            model_name='liability',
+            name='payments_remaining',
+            field=models.PositiveIntegerField(blank=True, help_text='Number of payments left', null=True),
+        ),
+        migrations.AddField(
+            model_name='liability',
+            name='interest_rate',
+            field=models.DecimalField(blank=True, decimal_places=2, help_text='Annual interest rate as a percentage', max_digits=5, null=True),
+        ),
+        migrations.AddField(
+            model_name='liability',
+            name='notes',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/finance_project/finance/models.py
+++ b/finance_project/finance/models.py
@@ -26,6 +26,34 @@ class Asset(models.Model):
 class Liability(models.Model):
     name = models.CharField(max_length=100)
     amount = models.DecimalField(max_digits=10, decimal_places=2)
+    payment_amount = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        help_text="Regular payment amount",
+    )
+    PAYMENT_FREQUENCY_CHOICES = [
+        ("week", "Weekly"),
+        ("month", "Monthly"),
+        ("year", "Yearly"),
+    ]
+    payment_frequency = models.CharField(
+        max_length=10,
+        choices=PAYMENT_FREQUENCY_CHOICES,
+        default="month",
+    )
+    payments_remaining = models.PositiveIntegerField(
+        null=True, blank=True, help_text="Number of payments left"
+    )
+    interest_rate = models.DecimalField(
+        max_digits=5,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        help_text="Annual interest rate as a percentage",
+    )
+    notes = models.TextField(blank=True)
 
     def __str__(self):
         return self.name

--- a/finance_project/finance/tests.py
+++ b/finance_project/finance/tests.py
@@ -11,7 +11,15 @@ class FinanceModelTests(TestCase):
         Asset.objects.create(name="Car", value=Decimal("10000"))
         BankAccount.objects.create(name="Checking", balance=Decimal("5000"), interest_rate=Decimal("5"))
         Stock.objects.create(name="ACME", shares=10, price=Decimal("20"), dividend_yield=Decimal("2"))
-        Liability.objects.create(name="Loan", amount=Decimal("3000"))
+        Liability.objects.create(
+            name="Loan",
+            amount=Decimal("3000"),
+            payment_amount=Decimal("250"),
+            payment_frequency="month",
+            payments_remaining=12,
+            interest_rate=Decimal("5"),
+            notes="Car loan",
+        )
 
     def test_projected_balance(self):
         acct = BankAccount.objects.get(name="Checking")

--- a/finance_project/finance/views.py
+++ b/finance_project/finance/views.py
@@ -141,13 +141,29 @@ class LiabilityDetail(ModelNameMixin, DetailView):
 
 class LiabilityCreate(ModelNameMixin, CreateView):
     model = Liability
-    fields = ['name', 'amount']
+    fields = [
+        'name',
+        'amount',
+        'payment_amount',
+        'payment_frequency',
+        'payments_remaining',
+        'interest_rate',
+        'notes',
+    ]
     template_name = 'finance/form.html'
     success_url = reverse_lazy('liability_list')
 
 class LiabilityUpdate(ModelNameMixin, UpdateView):
     model = Liability
-    fields = ['name', 'amount']
+    fields = [
+        'name',
+        'amount',
+        'payment_amount',
+        'payment_frequency',
+        'payments_remaining',
+        'interest_rate',
+        'notes',
+    ]
     template_name = 'finance/form.html'
     success_url = reverse_lazy('liability_list')
 


### PR DESCRIPTION
## Summary
- add payment details and interest rate fields to `Liability`
- expose new fields in liability CRUD views
- include migration for new fields
- update test setup for liability changes

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_683f662c52388333a80ea0de1134fe26